### PR TITLE
Fixing height declaration on footer.

### DIFF
--- a/app/assets/stylesheets/bootstrap_customisations.css.scss
+++ b/app/assets/stylesheets/bootstrap_customisations.css.scss
@@ -243,3 +243,7 @@ i.twitter {
   right: 1rem;
 }
 
+footer {
+  height: auto;
+  min-height: 4rem;
+}


### PR DESCRIPTION
With the current styles, the footer can get cut off in skinnier viewports. The declaration will fix it, but I'm making a wild guess as to where the new style needs to go because bootstrap. 

If you LMK how to compile and run the app, I can test it. Bonus points, I can beef up the readme. 😉 