### PR TITLE
Add field to define alternative workshop date

### DIFF
--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -91,6 +91,7 @@ class WorkshopsController < ApplicationController
     :start_time,
     :end_time,
     :time_zone,
+    :alternative_date,
     :ticketing_url,
     :organiser_id,
     :facilitator_id,

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,7 +1,7 @@
 <div id="intro" class="jumbotron">
   <h1><%= @workshop.city %>, <%= @workshop.country %></h1>
   <% if @workshop.start_time.present? && @workshop.end_time.present? %>
-  <h2><%= l @workshop.start_time %> till <%= l @workshop.end_time %> March 2nd 2019</h2>
+  <h2><%= l @workshop.start_time %> till <%= l @workshop.end_time %> <% if !@workshop.alternative_date.nil?  %><%= @workshop.alternative_date %> <% else %>March 2nd 2019<% end %></h2>
   <% end %>
   <% if @workshop.ticketing_url.present? %>
     <%= link_to "Book your free ticket", @workshop.ticketing_url, class: "ticket-button btn btn-warning", target: "blank" %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,7 +1,7 @@
 <div id="intro" class="jumbotron">
   <h1><%= @workshop.city %>, <%= @workshop.country %></h1>
   <% if @workshop.start_time.present? && @workshop.end_time.present? %>
-  <h2><%= l @workshop.start_time %> till <%= l @workshop.end_time %> <% if !@workshop.alternative_date.nil?  %><%= @workshop.alternative_date %> <% else %>March 2nd 2019<% end %></h2>
+  <h2><%= l @workshop.start_time %> till <%= l @workshop.end_time %> <% if @workshop.alternative_date.nil? || @workshop.alternative_date.empty?  %>March 2nd 2019<% else %><%= @workshop.alternative_date %><% end %></h2>
   <% end %>
   <% if @workshop.ticketing_url.present? %>
     <%= link_to "Book your free ticket", @workshop.ticketing_url, class: "ticket-button btn btn-warning", target: "blank" %>

--- a/app/views/workshops/_form.html.erb
+++ b/app/views/workshops/_form.html.erb
@@ -51,7 +51,7 @@
     </div>
     
     <div class="field">
-      <%= form.label :alternative_date, "Alternative workshop date" %>
+      <%= form.label :alternative_date, "If your event will happen in a different date, add it here. Format: Month day year, i.e March 15th 2019" %>
       <%= workshop_text_field(form, :alternative_date, "") %>
     </div>
   </div>

--- a/app/views/workshops/_form.html.erb
+++ b/app/views/workshops/_form.html.erb
@@ -49,6 +49,11 @@
       <%= form.label :time_zone %>
       <%= form.select :time_zone, timezone_codes, include_blank: true %>
     </div>
+    
+    <div class="field">
+      <%= form.label :alternative_date, "Alternative workshop date" %>
+      <%= workshop_text_field(form, :alternative_date, "") %>
+    </div>
   </div>
 
   <div class="grouping">

--- a/app/views/workshops/show.html.erb
+++ b/app/views/workshops/show.html.erb
@@ -69,6 +69,11 @@
       <strong>Time zone:</strong>
       <%= @workshop.time_zone %>
     </p>
+
+    <p>
+      <strong>Alternative date:</strong>
+      <%= @workshop.alternative_date %>
+    </p>
   </div>
 
   <div class="grouping">

--- a/db/migrate/20170723174039_create_workshops.rb
+++ b/db/migrate/20170723174039_create_workshops.rb
@@ -7,6 +7,7 @@ class CreateWorkshops < ActiveRecord::Migration[5.1]
       t.text :venue_address
       t.string :google_maps_url
       t.time :start_time
+      t.string :alternative_date
       t.time :end_time
       t.string :time_zone
       t.string :ticketing_url

--- a/db/migrate/20170723174039_create_workshops.rb
+++ b/db/migrate/20170723174039_create_workshops.rb
@@ -7,7 +7,6 @@ class CreateWorkshops < ActiveRecord::Migration[5.1]
       t.text :venue_address
       t.string :google_maps_url
       t.time :start_time
-      t.string :alternative_date
       t.time :end_time
       t.string :time_zone
       t.string :ticketing_url

--- a/db/migrate/20190210134037_add_alternative_date_to_workshops.rb
+++ b/db/migrate/20190210134037_add_alternative_date_to_workshops.rb
@@ -1,0 +1,5 @@
+class AddAlternativeDateToWorkshops < ActiveRecord::Migration[5.1]
+  def change
+    add_column :workshops, :alternative_date, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -107,6 +107,7 @@ ActiveRecord::Schema.define(version: 20181023074756) do
     t.text "venue_address"
     t.string "google_maps_url"
     t.time "start_time"
+    t.string "alternative_date"
     t.time "end_time"
     t.string "time_zone"
     t.string "ticketing_url"


### PR DESCRIPTION
## What? 
* Adds a string field in the workshop details, so event organizers can add an alternative date if they need it.

## How to test?
- Go to a workshop page and add a value in the alternative date.
The changes made here, will show  the alternative date in the workshop page if it exists. Otherwise show 2nd March