### PR TITLE
2020 Teaser

### DIFF
--- a/app/views/homepage/_workshops.html.erb
+++ b/app/views/homepage/_workshops.html.erb
@@ -2,18 +2,7 @@
 <% if workshops.empty? %>
   Currently we have no confirmed workshops. Please sign up below to organise a workshop.
 <% else %>
-    <ol class="workshop-list">
-      <%= link_to parents_path do %>
-        <li class="workshop-list-item">
-          Primary Parents Online Workshop
-          <button class="ticket-button btn btn-warning">Book your free ticket</button>
-        </li>
-        <% end %>
-    </ol>
-
   <% workshops.keys.each do |continent| %>
-    <br/>
-    <br/>
     <h3><%= continent %></h3>
     <% workshops[continent].keys.each do |country| %>
       <h4><%= country %></h4>

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -12,9 +12,6 @@
   <h2>
 
   </h2>
-  <% link_to "Schedule", schedule_index_path, class: "btn btn-warning" %>
-
-  <% link_to "Sign up to mailing list", mailing_list_sign_up_path, class: "btn btn-warning" %>
   <% link_to "Organise a workshop", organise_path, class: "ticket-button btn btn-warning" %>
 
   <% link_to "CFPs", cfps_path, class: "ticket-button btn btn-warning" %>
@@ -22,10 +19,10 @@
 
 </div>
 
-  <%= link_to "Celebrate 🎉", "https://goo.gl/forms/2kN6msbKrLhb2dIc2", class: "ticket-button btn btn-warning", target: "blank" %>
   <% link_to "Open CFPs", cfps_path, class: "ticket-button btn btn-warning right-margin" %>
-  <%= link_to "Example Proposals", proposals_path, class: "ticket-button btn btn-warning right-margin" %>
-  <%= link_to "Schedule", schedule_index_path, class: "btn btn-warning pull-right right-margin" %>
+  <%= link_to "Celebrate Your Talk being Accepted 🎉", "https://goo.gl/forms/2kN6msbKrLhb2dIc2", class: "ticket-button btn btn-warning", target: "blank" %>
+  <% link_to "Example Proposals", proposals_path, class: "ticket-button btn btn-warning right-margin" %>
+  <% link_to "Schedule", schedule_index_path, class: "btn btn-warning pull-right right-margin" %>
 <br/>
 <br/>
 <br/>

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -7,10 +7,10 @@
     Have you always wanted to become a tech conference speaker?
   </h2>
   <h2>
-    Let 2019 be the year that you make that dream a reality!
+    Let 2020 be the year that you make that dream a reality!
   </h2>
   <h2>
-
+    Announcements COMING SOON!
   </h2>
   <% link_to "Organise a workshop", organise_path, class: "ticket-button btn btn-warning" %>
 
@@ -28,12 +28,12 @@
 <br/>
 <div>
   <p>
-    <h2>Saturday 2nd March 2019</h2>
-    On Saturday 2nd March 2019 we will host the second edition of Global Diversity CFP Day following the success of the 2018 event where 53 workshops took place!
+    <h2>2020</h2>
+    In 2020 we will host the third edition of Global Diversity CFP Day following the success of the 2019 event where 81 workshops took place!
   </p>
 
   <p>
-    In 2019 there will be numerous workshops hosted around the globe encouraging and advising newbie speakers to put together your very first talk proposal and share your own individual perspective on any subject of interest to people in tech.
+    In 2020 there will be numerous workshops hosted around the globe encouraging and advising newbie speakers to put together your very first talk proposal and share your own individual perspective on any subject of interest to people in tech.
   </p>
 
   <p>
@@ -76,7 +76,7 @@
 
 <div id="organise">
   <p>
-    There have been many diversity outreach efforts in the past, and we are still on the long journey to achieve equality in tech. Please join us on Saturday 2nd March 2019 to take that first step to bring your unique voice to the stage.
+    There have been many diversity outreach efforts in the past, and we are still on the long journey to achieve equality in tech. Please join us in 2020 to take that first step to bring your unique voice to the stage.
   </p>
 
 </div>


### PR DESCRIPTION
The website still has details of the 2019 event visible.

Currently we don't have a date set for the 2020 event, but want to remove the 2019 info.

This PR:
* removes specific 2019 dates and replaces them with the general "2020" 
* adds "Announcements COMING SOON!" 
* and also removes the hardcoded Primary Parents Workshop