### PR TITLE
Restricting workshop creation to one per city per year

### DIFF
--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -2,6 +2,7 @@ class Workshop < ApplicationRecord
   default_scope { where(year: nil) }
 
   validates :continent, :country, :city, presence: true
+  validates_uniqueness_of :city, scope: :year
 
   MANDATORY_FIELDS_FOR_APPROVAL = [
     "continent",

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -6,6 +6,26 @@ RSpec.describe Workshop, type: :model do
     it { should validate_presence_of(:continent) }
     it { should validate_presence_of(:country) }
     it { should validate_presence_of(:city) }
+
+    describe "city" do
+      context "one workshop per city per year" do
+        it "is valid with more than one workshop per city when years are different" do
+          first = create_workshop(city: "Edinburgh", year: 2018)
+          second = create_workshop(city: "Edinburgh", year: 2019)
+          third = create_workshop(city: "Edinburgh", year: nil)
+
+          expect(Workshop.unscoped.count).to eql(3)
+        end
+
+        it "invalid to have more than one workshop per city per year" do
+          first = create_workshop(city: "Edinburgh", year: nil)
+          second = create_workshop(city: "Edinburgh", year: nil)
+
+          expect(first).to be_valid
+          expect(second).not_to be_valid
+        end
+      end
+    end
   end
 
   describe "default scope" do
@@ -502,7 +522,7 @@ RSpec.describe Workshop, type: :model do
     default_attributes = {
       continent: "Europe",
       country: "United Kingdom",
-      city: "Glasgow" ,
+      city: "Glasgow#{rand(999)}" ,
       venue_address: "City Centre",
       google_maps_url: "http://google.com",
       start_time: Time.now,


### PR DESCRIPTION
Issue: https://github.com/JiggyPete/global-diversity-cfp-day-site/issues/20

A number of situation have arisen in about 4 locations over the 2018 and 2019 editions of CFP Day where multiple people in the same :city wanted to be the workshop organiser. Both would sign up and have competing workshops.

I always expected people to first check the site, and when there was a workshop already in their location, reach out and team up.

This PR codifies that expectation and relieves us from an admin perspective of having to manage this politically.