### PR TITLE
Success Stories: V1

### DIFF
--- a/app/assets/stylesheets/bootstrap_customisations.css.scss
+++ b/app/assets/stylesheets/bootstrap_customisations.css.scss
@@ -501,6 +501,7 @@ footer {
   width: 200px;
   height: 200px;
   border-radius: 5%;
+  margin: 0 auto 0 auto;
 }
 
 .volunteer--details {
@@ -546,4 +547,61 @@ footer {
   left: 0;
   width: 100%;
   height: 100%;
+}
+
+.success-story {
+  .list {
+    list-style: none;
+    padding: 0;
+  }
+
+  .story {
+    background-color: $site-yellow;
+    width: 100%;
+    margin: 1.2em;
+    padding: 2em;
+    border-radius: 2%;
+    vertical-align: top;
+
+    @media (min-width: 1200px) {
+      width: 30%;
+      display: inline-block;
+    }
+
+    .details {
+      font-family: 'Comfortaa', cursive;
+      font-size: 20px;
+      font-weight: 500;
+      text-align: center;
+      line-height: 1.1;
+    }
+
+    .detail {
+      margin-top: 0.5em;
+    }
+
+    .name {
+      font-size: 30px;
+    }
+
+    .story-twitter {
+      display: inline;
+      width: 50px;
+      height: 50px;
+      position: relative;
+
+      .twitter {
+        @include twitter-icon;
+        margin-left: 75px;
+        margin-top: 20px;
+      }
+    }
+  }
+
+  .profile-picture {
+    width: 200px;
+    height: 200px;
+    border-radius: 5%;
+    border: 2px solid lightgrey;
+  }
 }

--- a/app/models/success_story.rb
+++ b/app/models/success_story.rb
@@ -1,0 +1,2 @@
+class SuccessStory < ApplicationRecord
+end

--- a/app/models/success_story.rb
+++ b/app/models/success_story.rb
@@ -12,4 +12,8 @@ class SuccessStory < ApplicationRecord
 
   validates :profile_picture_url, :url => true
 
+  def self.upcoming
+    where("event_start_date >= ?", Date.today).order(:event_start_date).first(3)
+  end
+
 end

--- a/app/models/success_story.rb
+++ b/app/models/success_story.rb
@@ -1,2 +1,15 @@
 class SuccessStory < ApplicationRecord
+
+  validates_presence_of :full_name,
+    :profile_picture_url,
+    :email_address,
+    :talk_title,
+    :event_name,
+    :event_start_date,
+    :event_end_date,
+    :premission_for_public_use,
+    :approved
+
+  validates :profile_picture_url, :url => true
+
 end

--- a/app/views/homepage/_upcoming_talks.html.erb
+++ b/app/views/homepage/_upcoming_talks.html.erb
@@ -1,0 +1,38 @@
+<% success_stories = SuccessStory.upcoming %>
+
+<% if success_stories.present? %>
+  <h2>Upcoming Talks from Attendees</h2>
+
+  <div class="row success-story">
+    <ul class="list">
+      <% success_stories.each do |participant| %>
+        <li class="story">
+          <%= image_tag participant.profile_picture_url, class: 'profile-picture center-block' %>
+          <div class="details">
+            <div class="detail name"><%= participant.full_name %></div>
+            <div class="detail"><%= participant.talk_title %></div>
+            <div class="detail"><%= participant.event_name %></div>
+            <div class="detail"><%= participant.event_start_date.strftime("%d %B %Y") %></div>
+            <div class="detail">
+              <% if participant.event_end_date.present? && participant.event_end_date != participant.event_start_date %>
+                  <%= participant.event_end_date.strftime("%d %B %Y") %>
+              <% else %>
+                &nbsp;
+              <% end %>
+            </div>
+
+            <div class="col col-sm-1 story-twitter center-block">
+              <a href="<%= 'http://twitter.com/' + participant.twitter %>" target="_blank">
+                <i class="twitter"></i>
+                <span class="sr-only">Follow <%= participant.full_name %> on Twitter</span>
+              </a>
+              &nbsp;
+            </div>
+
+          </div>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+
+<% end %>

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -29,6 +29,9 @@
 <br/>
 <br/>
 <br/>
+
+<%= render "upcoming_talks" %>
+
 <div>
   <p>
     <h2>Saturday 2nd March 2019</h2>

--- a/db/migrate/20190823081633_success_stories.rb
+++ b/db/migrate/20190823081633_success_stories.rb
@@ -1,0 +1,19 @@
+class SuccessStories < ActiveRecord::Migration[5.1]
+  def change
+    create_table :success_stories do |t|
+      t.string :full_name
+      t.string :twitter
+      t.string :profile_picture_url
+      t.string :email_address
+      t.string :talk_title
+      t.string :event_name
+      t.string :events_twitter
+      t.date :event_start_date
+      t.date :event_end_date
+      t.boolean :premission_for_public_use, default: false
+      t.boolean :approved, default: false
+    end
+  end
+end
+
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190224113103) do
+ActiveRecord::Schema.define(version: 20190823081633) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,20 @@ ActiveRecord::Schema.define(version: 20190224113103) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_incidents_on_user_id"
+  end
+
+  create_table "success_stories", force: :cascade do |t|
+    t.string "full_name"
+    t.string "twitter"
+    t.string "profile_picture_url"
+    t.string "email_address"
+    t.string "talk_title"
+    t.string "event_name"
+    t.string "events_twitter"
+    t.date "event_start_date"
+    t.date "event_end_date"
+    t.boolean "premission_for_public_use", default: false
+    t.boolean "approved", default: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/models/success_story_spec.rb
+++ b/spec/models/success_story_spec.rb
@@ -2,6 +2,23 @@ require 'rails_helper'
 
 RSpec.describe SuccessStory, type: :model do
 
+  def create_success_story(attributes)
+    default_attributes = {
+    full_name: "Fiona McDaid",
+    profile_picture_url: "https://twitter.com/fiona/profile_pic.jpg",
+    email_address: "fiona@gmail.com",
+    talk_title: "My Awesome Talk",
+    event_name: "The Tech Conference",
+    event_start_date: Date.new,
+    event_end_date: Date.new,
+    premission_for_public_use: true,
+    approved: true
+
+    }
+
+    SuccessStory.create( default_attributes.merge(attributes) )
+  end
+
   describe "validations" do
     it { should validate_presence_of(:full_name) }
     it { should validate_presence_of(:profile_picture_url) }
@@ -25,6 +42,114 @@ RSpec.describe SuccessStory, type: :model do
         subject = described_class.new profile_picture_url: "invalid"
         subject.valid?
         expect(subject.errors[:profile_picture_url]).to eql(["is not a valid URL"])
+      end
+    end
+  end
+
+  describe "upcoming" do
+    context "with no success stories" do
+      it "provides no success stories" do
+        expect(SuccessStory.upcoming.length).to eql(0)
+      end
+    end
+
+    context "with past success stories" do
+      context "with one past success story" do
+        it "provides no upcoming success stories" do
+          create_success_story event_start_date: Date.yesterday
+          expect(SuccessStory.upcoming.length).to eql(0)
+        end
+      end
+
+      context "with two past success story" do
+        it "provides no success stories" do
+          create_success_story event_start_date: Date.yesterday
+          create_success_story event_start_date: 2.days.ago
+
+          expect(SuccessStory.upcoming.length).to eql(0)
+        end
+      end
+
+      context "with three past success story" do
+        it "provides no success stories" do
+          create_success_story event_start_date: Date.yesterday
+          create_success_story event_start_date: 2.days.ago
+          create_success_story event_start_date: 3.days.ago
+
+          expect(SuccessStory.upcoming.length).to eql(0)
+        end
+      end
+    end
+
+    context "with a success story today" do
+      it "provides upcoming success stories" do
+        create_success_story event_start_date: Date.today
+        expect(SuccessStory.upcoming.length).to eql(1)
+      end
+    end
+
+    context "with multiple success stories today" do
+      it "provides upcoming success stories" do
+        create_success_story event_start_date: Date.today
+        create_success_story event_start_date: Date.today
+        create_success_story event_start_date: Date.today
+        expect(SuccessStory.upcoming.length).to eql(3)
+      end
+    end
+
+    context "with multiple success stories today with multiple past success stories" do
+      it "provides upcoming success stories" do
+        create_success_story event_start_date: Date.yesterday
+        create_success_story event_start_date: Date.yesterday
+        create_success_story event_start_date: Date.today, full_name: "Todays First Success"
+        create_success_story event_start_date: Date.today, full_name: "Todays Second Success"
+        create_success_story event_start_date: Date.today, full_name: "Todays Third Success"
+
+        names = SuccessStory.upcoming.map(&:full_name)
+        names.each do |name|
+          expect( ["Todays First Success", "Todays Second Success", "Todays Third Success"] ).to include(name)
+        end
+      end
+    end
+
+    context "with multiple future success stories" do
+      it "provides upcoming success stories" do
+        create_success_story event_start_date: Date.today
+        create_success_story event_start_date: Date.tomorrow
+        create_success_story event_start_date: Date.tomorrow
+
+        expect(SuccessStory.upcoming.length).to eql(3)
+      end
+    end
+
+    context "with multiple future success stories" do
+      it "only provides upcoming success stories with premission_for_public_use" do
+        create_success_story event_start_date: Date.tomorrow, premission_for_public_use: false
+        create_success_story event_start_date: Date.tomorrow, premission_for_public_use: true
+        create_success_story event_start_date: Date.tomorrow, premission_for_public_use: true
+
+        expect(SuccessStory.upcoming.length).to eql(2)
+      end
+
+      it "only provides approved upcoming success stories" do
+        create_success_story event_start_date: Date.tomorrow, approved: false
+        create_success_story event_start_date: Date.tomorrow, approved: true
+        create_success_story event_start_date: Date.tomorrow, approved: true
+
+        expect(SuccessStory.upcoming.length).to eql(2)
+      end
+
+      it "limits upcoming success stories to nearest three" do
+        create_success_story event_start_date: 4.days.from_now, full_name: "Not returned"
+
+        create_success_story event_start_date: 2.days.from_now, full_name: "Second"
+        create_success_story event_start_date: 1.day.from_now, full_name: "First"
+        create_success_story event_start_date: 3.days.from_now, full_name: "Third"
+
+        expect(SuccessStory.upcoming.length).to eql(3)
+        expect(SuccessStory.upcoming[0].full_name).to eql("First")
+        expect(SuccessStory.upcoming[1].full_name).to eql("Second")
+        expect(SuccessStory.upcoming[2].full_name).to eql("Third")
       end
     end
   end

--- a/spec/models/success_story_spec.rb
+++ b/spec/models/success_story_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe SuccessStory, type: :model do
+
+  describe "validations" do
+    it { should validate_presence_of(:full_name) }
+    it { should validate_presence_of(:profile_picture_url) }
+    it { should validate_presence_of(:email_address) }
+    it { should validate_presence_of(:talk_title) }
+    it { should validate_presence_of(:event_name) }
+    it { should validate_presence_of(:event_start_date) }
+    it { should validate_presence_of(:event_end_date) }
+    it { should validate_presence_of(:premission_for_public_use) }
+    it { should validate_presence_of(:approved) }
+
+
+    context "profile_picture_url" do
+      it "accepts a valid url" do
+        subject = described_class.new profile_picture_url: "http://google.com"
+        subject.valid?
+        expect(subject.errors[:profile_picture_url]).to be_empty
+      end
+
+      it "doesn't accept an invalid url" do
+        subject = described_class.new profile_picture_url: "invalid"
+        subject.valid?
+        expect(subject.errors[:profile_picture_url]).to eql(["is not a valid URL"])
+      end
+    end
+  end
+
+end
+


### PR DESCRIPTION
:octocat: [Issue](https://github.com/JiggyPete/global-diversity-cfp-day-site/issues/49)

Here we 
* created a `SuccessStory` model with the attributes mention in the Issue ☝️ 
* Added a `:upcoming` scope to `SuccessStory` to provide the next 3 talks registered by attendees.
* Updated the homepage to display these


![Screenshot 2019-09-01 at 16 46 32](https://user-images.githubusercontent.com/67151/64078855-18a54f80-ccd8-11e9-9268-dde60cab7ebd.png)

