### PR TITLE
Update "Duplicate last years workshop" functionality

### DIFF
--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -3,8 +3,8 @@ class WorkshopsController < ApplicationController
 
   def duplicate
     previous_workshop = Workshop.unscoped.find( current_user.workshop_id )
-    new_workshop = previous_workshop.duplicate_for_2019(current_user)
-    flash[:success] = "Successfully duplicated your teams 2018 workshop. All you need now is a ticketing url."
+    new_workshop = previous_workshop.duplicate_for_2020(current_user)
+    flash[:success] = "Successfully duplicated your teams 2019 workshop. All you need now is a ticketing url."
     redirect_to workshop_path(new_workshop)
   end
 

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -2,7 +2,7 @@ class WorkshopsController < ApplicationController
   before_action :set_workshop, only: [:show, :edit, :update, :destroy, :duplicate]
 
   def duplicate
-    previous_workshop = Workshop.unscoped.find( current_user.workshop_id )
+    previous_workshop = Workshop.previous_workshop_for( current_user )
     new_workshop = previous_workshop.duplicate_for_2020(current_user)
     flash[:success] = "Successfully duplicated your teams 2019 workshop. All you need now is a ticketing url."
     redirect_to workshop_path(new_workshop)
@@ -17,6 +17,9 @@ class WorkshopsController < ApplicationController
     end
 
     @workshop = Workshop.new
+  end
+
+  def new_duplicate
   end
 
   def edit

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,7 +2,10 @@ module ApplicationHelper
   def workshop_landing_page_for(user)
     return admin_workshops_path if user.admin?
 
-    user.workshop_id.present? ?  workshop_path(user.workshop_id) : new_workshop_path
+    return workshop_path(user.workshop) if user.workshop.present?
+    return workshop_new_duplicate_path(user.workshop_id) if Workshop.previous_workshop_for( user ).present?
+
+    new_workshop_path
   end
 
   def user_name(user)

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -20,7 +20,7 @@ class Workshop < ApplicationRecord
   ]
 
   def self.previous_workshop_for(user)
-    Workshop.unscoped.find_by(id: user.workshop_id, year: 2018)
+    Workshop.unscoped.find_by(id: user.workshop_id, year: 2019)
   end
 
   def self.workshops_grouped_for_homepage
@@ -48,20 +48,20 @@ class Workshop < ApplicationRecord
     result
   end
 
-  def duplicate_for_2019(duplicated_by_user)
-    workshop_for_2019 = duplicate_2018_workshop
-    migrate_team_to! workshop_for_2019
+  def duplicate_for_2020(duplicated_by_user)
+    workshop_for_2020 = duplicate_2019_workshop
+    migrate_team_to! workshop_for_2020
     update_team_roles!(duplicated_by_user)
 
-    workshop_for_2019
+    workshop_for_2020
   end
 
-  def migrate_team_to!(workshop_for_2019)
-    organiser.update workshop: workshop_for_2019 if organiser.present?
-    facilitator.update workshop: workshop_for_2019 if facilitator.present?
+  def migrate_team_to!(workshop_for_2020)
+    organiser.update workshop: workshop_for_2020 if organiser.present?
+    facilitator.update workshop: workshop_for_2020 if facilitator.present?
 
     mentors.each do |mentor|
-      mentor.update workshop: workshop_for_2019
+      mentor.update workshop: workshop_for_2020
     end
   end
 
@@ -118,7 +118,7 @@ class Workshop < ApplicationRecord
     MANDATORY_FIELDS_FOR_APPROVAL.map {|attr| send(attr) }
   end
 
-  def duplicate_2018_workshop
+  def duplicate_2019_workshop
     result = self.dup
     result.year = nil
     result.ticketing_url = nil

--- a/app/views/workshops/_form.html.erb
+++ b/app/views/workshops/_form.html.erb
@@ -15,14 +15,14 @@
     <%= form.submit class: "btn btn-warning"%>
   </div>
 
-  <div class="grouping">
+<!--   <div class="grouping">
     <h2>Attendees</h2>
 
     <%= workshop_text_field(form, :number_of_sign_ups, "") %>
     <%= workshop_text_field(form, :number_of_attendees, "") %>
 
   </div>
-
+ -->
   <div class="grouping">
     <h2>Where</h2>
     <div class="field">

--- a/app/views/workshops/new_duplicate.html.erb
+++ b/app/views/workshops/new_duplicate.html.erb
@@ -1,0 +1,11 @@
+<p>
+  Having been involved in Global Diversity CFP Day 2019, we want to make the setup of your 2020 workshop as easy as possible. If you intend hosting in the same venue as 2019 we'd recommend you...
+</p>
+<%= link_to 'Duplicate 2019 Workshop', workshop_duplicate_path, class: 'btn btn-warning pull-left', method: :post %>
+<br/>
+<br/>
+<br/>
+<p>
+  otherwise you can create a fresh new workshop here
+</p>
+<%= link_to 'New 2020 Workshop', new_workshop_path, class: 'btn btn-warning pull-left' %>

--- a/app/views/workshops/show.html.erb
+++ b/app/views/workshops/show.html.erb
@@ -1,17 +1,3 @@
-<% if @workshop.nil? && current_user.workshop_id.present? %>
-  <p>
-    Having been involved in Global Diversity CFP Day 2018, we want to make the setup of your 2019 workshop as easy as possible. If you intend hosting in the same venue as 2018 we'd recommend you...
-  </p>
-  <%= link_to 'Duplicate 2018 Workshop', workshop_duplicate_path, class: 'btn btn-warning pull-left', method: :post %>
-  <br/>
-  <br/>
-  <br/>
-  <p>
-    otherwise you can create a fresh new workshop here
-  </p>
-  <%= link_to 'New 2019 Workshop', new_workshop_path, class: 'btn btn-warning pull-left' %>
-<% end %>
-
 <% if @workshop.present? %>
   <h1>Workshop Management</h1>
   <p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   resources :events, only: :show
 
   post "/workshop/duplicate" => "workshops#duplicate"
+  get "/workshop/new_duplicate" => "workshops#new_duplicate"
   resources :workshops, only: [:new, :show, :create, :edit, :update, :destroy]
   resources :parents, only: :index
   resources :users, only: [:destroy]

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+
+  describe "#workshop_landing_page_for" do
+    context "admin user signs in" do
+      it "supplies the admin workshops path" do
+        admin = User.new(admin: true)
+        expect(helper.workshop_landing_page_for(admin)).to eql(admin_workshops_path)
+      end
+    end
+
+    context "signed up user with a 2020 workshop signs in" do
+      it "supplies the path to the workshop :show" do
+        workshop = Workshop.new(id: 700, year: nil)
+        user = User.new(workshop: workshop)
+
+        expect(helper.workshop_landing_page_for(user)).to eql(workshop_path(700))
+      end
+    end
+
+    context "signed up user with only a 2019 workshop signs in" do
+      it "supplies the path to the workshop :new_duplicate" do
+        workshop = Workshop.create(id: 700, year: 2019, continent: "Asia", country: "Japan", city: "Tokyo" )
+        user = User.new(workshop_id: 700)
+
+        expect(helper.workshop_landing_page_for(user)).to eql(workshop_new_duplicate_path(700))
+      end
+    end
+
+    context "signed up user with only a 2018 or previous workshop signs in" do
+      it "supplies the new_workshop_path" do
+        workshop = Workshop.create(id: 700, year: 2018, continent: "Asia", country: "Japan", city: "Tokyo" )
+        user = User.new(workshop_id: 700)
+
+        expect(helper.workshop_landing_page_for(user)).to eql(new_workshop_path)
+      end
+    end
+
+    context "newly created user with no workshop signs in" do
+      it "supplies the new_workshop_path" do
+        user = User.new(workshop: nil)
+
+        expect(helper.workshop_landing_page_for(user)).to eql(new_workshop_path)
+      end
+    end
+  end
+end

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -31,18 +31,18 @@ RSpec.describe Workshop, type: :model do
   describe "default scope" do
     it "provides workshops with no :year set" do
       no_year  = create_workshop year: nil
-      year_2018  = create_workshop year: 2018
+      year_2019  = create_workshop year: 2019
 
-      expect(Workshop.all).not_to include(year_2018)
-      expect(Workshop.unscoped.all).to include(year_2018)
+      expect(Workshop.all).not_to include(year_2019)
+      expect(Workshop.unscoped.all).to include(year_2019)
 
       expect(Workshop.all).to include(no_year)
     end
   end
 
   describe "#previous_workshop_for" do
-    it "provides the 2018 workshop, when one exists for user" do
-      original_workshop = create_workshop year: 2018
+    it "provides the 2019 workshop, when one exists for user" do
+      original_workshop = create_workshop year: 2019
       user = create_user(organiser: true, workshop: original_workshop)
 
       expect(Workshop.previous_workshop_for user).to eql(original_workshop)
@@ -61,8 +61,8 @@ RSpec.describe Workshop, type: :model do
     end
   end
 
-  describe "#duplicate_for_2019" do
-    let(:original_workshop) { create_workshop year: 2018 }
+  describe "#duplicate_for_2020" do
+    let(:original_workshop) { create_workshop year: 2019 }
     let!(:organiser) { create_user(organiser: true, workshop: original_workshop) }
     let!(:facilitator) { create_user(facilitator: true, workshop: original_workshop) }
     let!(:mentor_1) { create_user(mentor: true, workshop: original_workshop) }
@@ -70,7 +70,7 @@ RSpec.describe Workshop, type: :model do
     let!(:mentor_3) { create_user(mentor: true, workshop: original_workshop) }
 
     it "creates and returns a duplicate workshop" do
-      new_workshop = original_workshop.duplicate_for_2019(organiser)
+      new_workshop = original_workshop.duplicate_for_2020(organiser)
 
       expect(new_workshop.id).not_to eql(original_workshop.id)
       expect(new_workshop.year).to be_nil
@@ -78,12 +78,12 @@ RSpec.describe Workshop, type: :model do
 
     it "handle previous organiser being nil" do
       organiser.destroy
-      new_workshop = original_workshop.duplicate_for_2019(organiser)
+      new_workshop = original_workshop.duplicate_for_2020(organiser)
       expect(new_workshop.organiser).to be_nil
     end
 
     it "previous organiser is migrated to new workshop" do
-      new_workshop = original_workshop.duplicate_for_2019(organiser)
+      new_workshop = original_workshop.duplicate_for_2020(organiser)
 
       organiser.reload
       expect(organiser.workshop).to eql(new_workshop)
@@ -97,12 +97,12 @@ RSpec.describe Workshop, type: :model do
 
     it "handle previous facilitator being nil" do
       facilitator.destroy
-      new_workshop = original_workshop.duplicate_for_2019(organiser)
+      new_workshop = original_workshop.duplicate_for_2020(organiser)
       expect(new_workshop.facilitator).to be_nil
     end
 
     it "previous facilitator is migrated to new workshop" do
-      new_workshop = original_workshop.duplicate_for_2019(organiser)
+      new_workshop = original_workshop.duplicate_for_2020(organiser)
 
       facilitator.reload
       expect(facilitator.workshop).to eql(new_workshop)
@@ -119,12 +119,12 @@ RSpec.describe Workshop, type: :model do
       mentor_2.destroy
       mentor_3.destroy
 
-      new_workshop = original_workshop.duplicate_for_2019(organiser)
+      new_workshop = original_workshop.duplicate_for_2020(organiser)
       expect(new_workshop.mentors).to be_empty
     end
 
     it "previous mentors are migrated to new workshop" do
-      new_workshop = original_workshop.duplicate_for_2019(organiser)
+      new_workshop = original_workshop.duplicate_for_2020(organiser)
 
       [mentor_1, mentor_2, mentor_3].each do |mentor|
         mentor.reload
@@ -140,19 +140,19 @@ RSpec.describe Workshop, type: :model do
 
     it "does not duplicate previous ticketing_url" do
       expect(original_workshop.ticketing_url).not_to be_nil
-      new_workshop = original_workshop.duplicate_for_2019(organiser)
+      new_workshop = original_workshop.duplicate_for_2020(organiser)
       expect(new_workshop.ticketing_url).to be_nil
     end
 
     context "when the duplicating user was last years facilitator" do
       it "makes the original facilitator the organiser" do
-        new_workshop = original_workshop.duplicate_for_2019(facilitator)
+        new_workshop = original_workshop.duplicate_for_2020(facilitator)
         facilitator.reload
         expect(new_workshop.organiser).to eql(facilitator)
       end
 
       it "makes the original organiser a mentor" do
-        new_workshop = original_workshop.duplicate_for_2019(facilitator)
+        new_workshop = original_workshop.duplicate_for_2020(facilitator)
         organiser.reload
         expect(new_workshop.mentors).to include(organiser)
       end
@@ -160,13 +160,13 @@ RSpec.describe Workshop, type: :model do
 
     context "when the duplicating user was last years mentor" do
       it "makes the original mentor the organiser" do
-        new_workshop = original_workshop.duplicate_for_2019(mentor_1)
+        new_workshop = original_workshop.duplicate_for_2020(mentor_1)
         mentor_1.reload
         expect(new_workshop.organiser).to eql(mentor_1)
       end
 
       it "makes the original organiser a mentor" do
-        new_workshop = original_workshop.duplicate_for_2019(mentor_1)
+        new_workshop = original_workshop.duplicate_for_2020(mentor_1)
         organiser.reload
         expect(new_workshop.mentors).to include(organiser)
       end


### PR DESCRIPTION
:octocat: [Issue](https://github.com/JiggyPete/global-diversity-cfp-day-site/issues/62)

When running the 2019 event, this logic applied to workshop team members that had been involved in a2018 workshop or not been involved at all.

Due to having to handle a 3rd scenario, where there is now historical 2018 workshops, and users can only duplicate the most recent (2019) this PR was a little more involved than expected.

**Approach:**
1: Rename all the "2019"s to "2020"s
2: Rename all the "2018"s to "2019"s 
3: Simplify workshops#show template by introducing new step in the flow: "new_duplicate"