### PR TITLE
Define CFP early on the homepage

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/thoughtbot/shoulda-matchers.git
-  revision: edaf9cb926ee9c59c59729e7a4f8c206b44da8a1
+  revision: 1201198f959809d7a82b51b66e878fb1d9b856e3
   branch: rails-5
   specs:
     shoulda-matchers (3.1.2)

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -26,8 +26,18 @@
 <br/>
 <br/>
 <br/>
-
 <%= render "upcoming_talks" %>
+
+<div>
+  <h2>Call For Proposals</h2>
+  <p>
+  Events or conferences looking for speakers start a process called "Call for Proposals". This is an invite for anyone interested in taking part to submit their idea for a talk or workshop. Proposals - or plans - are an outline of what you'd like to talk about and helps organisers choose the right talks for their events.
+  </p>
+  <p>
+  The global diversity CFP day is here to help you craft that proposal, and reduce any worry you may have when submitting.
+  </p>
+</div>
+<br />
 
 <div>
   <p>

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -29,7 +29,7 @@
 <%= render "upcoming_talks" %>
 
 <div>
-  <h2>Call For Proposals</h2>
+  <h2>Call For Proposals (CFP)</h2>
   <p>
   Events or conferences looking for speakers start a process called "Call for Proposals". This is an invite for anyone interested in taking part to submit their idea for a talk or workshop. Proposals - or plans - are an outline of what you'd like to talk about and helps organisers choose the right talks for their events.
   </p>


### PR DESCRIPTION
Define CFP on the homepage as one of the first blocks of content.

closes #39 

----
<img width="1315" alt="image" src="https://user-images.githubusercontent.com/6391616/64416792-c5445000-d08f-11e9-89cd-d034018458ee.png">
