### PR TITLE
add 'Newly Registered Workshops' to the homepage

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -3,5 +3,6 @@ class HomepageController < ApplicationController
 
   def index
     @workshops = Workshop.workshops_grouped_for_homepage
+    @newest_workshops = Workshop.newest_workshops_by_continent
   end
 end

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -23,14 +23,22 @@ class Workshop < ApplicationRecord
     Workshop.unscoped.find_by(id: user.workshop_id, year: 2019)
   end
 
-  def self.workshops_grouped_for_homepage
-    result = Workshop.all.order(:continent, :country, :city).group_by(&:continent)
+  def self.group_by_continent_and_country(workshops)
+    result = workshops.reorder(:continent, :country, :city).group_by(&:continent)
 
     result.keys.each do |continent|
       result[continent] = result[continent].group_by(&:country)
     end
 
     result
+  end
+
+  def self.newest_workshops_by_continent
+    Workshop.group_by_continent_and_country(Workshop.all.order(created_at: :desc).limit(5))
+  end
+
+  def self.workshops_grouped_for_homepage
+    Workshop.group_by_continent_and_country(Workshop.all)
   end
 
   def awaiting_invitation_acceptance?(user)

--- a/app/views/homepage/_confirmed_workshops.html.erb
+++ b/app/views/homepage/_confirmed_workshops.html.erb
@@ -1,0 +1,6 @@
+<h2>Workshops</h2>
+<% if workshops.empty? %>
+  Currently we have no confirmed workshops. Please sign up below to organise a workshop.
+<% else %>
+  <%= render  partial: "workshops",  :locals => {:workshops => @workshops} %>
+<% end %>

--- a/app/views/homepage/_newest_workshops.html.erb
+++ b/app/views/homepage/_newest_workshops.html.erb
@@ -1,0 +1,16 @@
+<% new_workshops = Workshop.all.order(created_at: :desc).limit(5) %>
+
+<% if new_workshops.any? %>
+  <h2>Newly Registered Workshops</h2>
+  <div class="row">
+    <ul class="list">
+      <% new_workshops.each do |workshop| %>
+        <li>
+          <a href="<%= '/workshops/%d' % [workshop.id] %>"><%= workshop.city %>, <%= workshop.country %></a>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<br />
+<br />
+<% end %>

--- a/app/views/homepage/_newest_workshops.html.erb
+++ b/app/views/homepage/_newest_workshops.html.erb
@@ -1,16 +1,6 @@
-<% new_workshops = Workshop.all.order(created_at: :desc).limit(5) %>
-
-<% if new_workshops.any? %>
+<% if workshops.any? %>
   <h2>Newly Registered Workshops</h2>
-  <div class="row">
-    <ul class="list">
-      <% new_workshops.each do |workshop| %>
-        <li>
-          <a href="<%= '/workshops/%d' % [workshop.id] %>"><%= workshop.city %>, <%= workshop.country %></a>
-        </li>
-      <% end %>
-    </ul>
-  </div>
+  <%= render  partial: "workshops",  :locals => {:workshops => @workshops} %>
 <br />
 <br />
 <% end %>

--- a/app/views/homepage/_workshops.html.erb
+++ b/app/views/homepage/_workshops.html.erb
@@ -1,22 +1,17 @@
-<h2>Workshops</h2>
-<% if workshops.empty? %>
-  Currently we have no confirmed workshops. Please sign up below to organise a workshop.
-<% else %>
-  <% workshops.keys.each do |continent| %>
-    <h3><%= continent %></h3>
-    <% workshops[continent].keys.each do |country| %>
-      <h4><%= country %></h4>
-      <ol class="workshop-list">
-      <% workshops[continent][country].each do |workshop| %>
-        <% link_text = workshop.ticketing_url.present? ? "Book your free ticket" : "View details" %>
-        <%= link_to event_path(workshop) do %>
-          <li class="workshop-list-item">
-            <%= workshop.city %>
-            <button class="ticket-button btn btn-warning"><%= link_text %></button>
-          </li>
-        <% end %>
+<% workshops.keys.each do |continent| %>
+  <h3><%= continent %></h3>
+  <% workshops[continent].keys.each do |country| %>
+    <h4><%= country %></h4>
+    <ol class="workshop-list">
+    <% workshops[continent][country].each do |workshop| %>
+      <% link_text = workshop.ticketing_url.present? ? "Book your free ticket" : "View details" %>
+      <%= link_to event_path(workshop) do %>
+        <li class="workshop-list-item">
+          <%= workshop.city %>
+          <button class="ticket-button btn btn-warning"><%= link_text %></button>
+        </li>
       <% end %>
-      </ol>
     <% end %>
+    </ol>
   <% end %>
 <% end %>

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -26,6 +26,8 @@
 <br/>
 <br/>
 <br/>
+<%= render "newest_workshops" %>
+
 <%= render "upcoming_talks" %>
 
 <div>

--- a/app/views/homepage/index.html.erb
+++ b/app/views/homepage/index.html.erb
@@ -26,7 +26,7 @@
 <br/>
 <br/>
 <br/>
-<%= render "newest_workshops" %>
+<%= render  partial: "newest_workshops",  :locals => {:workshops => @newest_workshops} %>
 
 <%= render "upcoming_talks" %>
 

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -496,6 +496,68 @@ RSpec.describe Workshop, type: :model do
 
 
   end
+  describe "newest_workshops_by_continent groups by country, sorted by city" do
+    context "when no workshops exist" do
+      it "has no workshops" do
+        expect(Workshop.newest_workshops_by_continent).to be_empty
+      end
+    end
+
+    context "has a number of workshops in the same city" do
+      it "sorts workshops by city name" do
+        aberdeen = create_workshop country: "United Kingdom", city: "Aberdeen"
+        glasgow = create_workshop country: "United Kingdom", city: "Glasgow"
+        edinburgh = create_workshop country: "United Kingdom", city: "Edinburgh"
+
+        workshops = Workshop.newest_workshops_by_continent["Europe"]["United Kingdom"]
+        expect(workshops.length).to eql(3)
+        expect(workshops).to eql([aberdeen, edinburgh, glasgow])
+      end
+    end
+
+    context "sorts cities grouped by country" do
+      it "sorts workshops by city name" do
+        new_york = create_workshop country: "United States", city: "New York"
+        glasgow = create_workshop country: "United Kingdom", city: "Glasgow"
+        boston = create_workshop country: "United States", city: "Boston"
+
+        result = Workshop.all.order(:city).group_by(&:country)
+
+        expect(result.length).to eql(2)
+        uk = result["United Kingdom"]
+        usa = result["United States"]
+
+        expect(uk).to eql([glasgow])
+        expect(usa).to eql([boston, new_york])
+      end
+    end
+
+    context "countries cities grouped by country and continent" do
+      it "sorts workshops by city name" do
+        new_york = create_workshop continent: "North America", country: "United States", city: "New York"
+        glasgow = create_workshop continent: "Europe", country: "United Kingdom", city: "Glasgow"
+        amsterdam = create_workshop continent: "Europe", country: "Holland", city: "Amsterdam"
+        boston = create_workshop continent: "North America", country: "United States", city: "Boston"
+        toronto = create_workshop continent: "North America", country: "Canada", city: "Toronto"
+
+        result = Workshop.newest_workshops_by_continent
+
+        expect(result.length).to eql(2)
+        europe = result["Europe"]
+        north_america = result["North America"]
+
+        expect(europe.length).to eql(2)
+        expect(europe["Holland"]).to eql([amsterdam])
+        expect(europe["United Kingdom"]).to eql([glasgow])
+
+        expect(north_america.length).to eql(2)
+        expect(north_america["Canada"]).to eql([toronto])
+        expect(north_america["United States"]).to eql([boston, new_york])
+      end
+    end
+
+
+  end
 
   def create_organiser(workshop)
     create_user email: "organiser@example.com", organiser: true, workshop: workshop


### PR DESCRIPTION
### Summary
Shows the 5 most recently registered workshops in a list on the homepage.

### Notes

I'm not 100% sure about the positioning - the github issue didn't specify so I don't know if it should sit higher or lower than the "upcoming talks" section. Happy to move things around.

I've also haven't written Ruby until this morning so if this isn't the right approach do let me know 😄 


Closes #52 

----
<img width="1363" alt="image" src="https://user-images.githubusercontent.com/6391616/65221103-31717b80-dab4-11e9-9a2c-d04ae3e8b4ae.png">

