### PR TITLE
add padding to Code of Conduct page

### DIFF
--- a/app/assets/stylesheets/code_of_conduct.scss
+++ b/app/assets/stylesheets/code_of_conduct.scss
@@ -1,0 +1,14 @@
+// Place all the styles related to the Code of Conduct controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/
+
+
+.CodeOfConduct {
+  &__Issue {
+    margin-top: 5rem;
+  }
+  
+  &__Section {
+    margin-bottom: 5rem;
+  }
+}

--- a/app/views/code_of_conduct/index.html.erb
+++ b/app/views/code_of_conduct/index.html.erb
@@ -1,60 +1,58 @@
-<h1>Code of Conduct</h1>
+<section class="CodeOfConduct__Section">
+  <h1>Code of Conduct</h1>
 
-<p>
-  All attendees, workshop organisers, facilitators, mentors and venue staff involved in Global Diversity CFP Day are required to agree with the following code of conduct.
-</p>
-<p>
-  Workshop team members will enforce this code of conduct throughout the event.
-</p>
-<br/>
-<p>
-  <b>We value the diversity and inclusion of underrepresented and marginalized people in tech.</b>
-</p>
-<p>
-  Be mindful that this will likely be the most diverse group of people that you have been around and can expect to meet people from a wide range of religions, ethnicities, genders, gender identities, nationalities, sexual orientations, body sizes, physical appearance, mental abilities and physical abilities.
-</p>
-<p>
-  Use this as an opportunity to respectfully interact with a diverse group of individuals in a professional and safe environment.
-</p>
+  <p>
+    All attendees, workshop organisers, facilitators, mentors and venue staff involved in Global Diversity CFP Day are required to agree with the following code of conduct.
+  </p>
+  <p>
+    Workshop team members will enforce this code of conduct throughout the event.
+  </p>
+  <br/>
+  <p>
+    <b>We value the diversity and inclusion of underrepresented and marginalized people in tech.</b>
+  </p>
+  <p>
+    Be mindful that this will likely be the most diverse group of people that you have been around and can expect to meet people from a wide range of religions, ethnicities, genders, gender identities, nationalities, sexual orientations, body sizes, physical appearance, mental abilities and physical abilities.
+  </p>
+  <p>
+    Use this as an opportunity to respectfully interact with a diverse group of individuals in a professional and safe environment.
+  </p>
 
-<p>
-  We are all here to learn and grow. This event, being a professional and safe environment, is not the appropriate venue to question individuals on their underrepresented status.
-</p>
-<p>
-  Anyone found to be behaving in any way that makes participants uncomfortable or impedes the intended goals of this event will be in violation of this Code of Conduct and will be ejected from Global Diversity CFP Day.
-</p>
+  <p>
+    We are all here to learn and grow. This event, being a professional and safe environment, is not the appropriate venue to question individuals on their underrepresented status.
+  </p>
+  <p>
+    Anyone found to be behaving in any way that makes participants uncomfortable or impedes the intended goals of this event will be in violation of this Code of Conduct and will be ejected from Global Diversity CFP Day.
+  </p>
 
-<p>
-  Offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, unwelcome photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention are also considered inappropriate behaviour.
-</p>
-<p>
-  If your behavior proves to be harmful to others you will have to be removed from all Global Diversity CFP Day events.
-</p>
-<p>
-  If you or someone else are subjected to inappropriate behaviour or have any other concerns please follow the Reporting steps below.
-</p>
+  <p>
+    Offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, unwelcome photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention are also considered inappropriate behaviour.
+  </p>
+  <p>
+    If your behavior proves to be harmful to others you will have to be removed from all Global Diversity CFP Day events.
+  </p>
+  <p>
+    If you or someone else are subjected to inappropriate behaviour or have any other concerns please follow the Reporting steps below.
+  </p>
+</section>
 
-
-<br/>
-<h2>Reporting Steps</h2>
-<p>
-  The workshop teams are here to help attendees feel safe for the duration of the workshop. We value your participation.</p>
-</p>
-<p>
-  If you need to report an incident please contact a member of your workshop team. Various means to report violations to the local team will be visible throughout each workshop if you are uncomfortable approaching a team member in person.
-</p>
-<p>
-  If the person you need to report is a member of the workshop team please contact the workshop organiser.
-</p>
-<p>
-  If the person you need to report is the workshop organiser, please contact the
-  <a class="btn btn-warning" href="mailto:coc@globaldiversitycfpday.com?Subject=Code%20of%20Conduct%20Issue&body=Location%0A%0AIssue">Global Code of Conduct Team</a>
-</p>
-<br/>
-
-
-
-
+<section class="CodeOfConduct__Section">
+  <h2>Reporting Steps</h2>
+  <p>
+    The workshop teams are here to help attendees feel safe for the duration of the workshop. We value your participation.</p>
+  </p>
+  <p>
+    If you need to report an incident please contact a member of your workshop team. Various means to report violations to the local team will be visible throughout each workshop if you are uncomfortable approaching a team member in person.
+  </p>
+  <p>
+    If the person you need to report is a member of the workshop team please contact the workshop organiser.
+  </p>
+  <p>
+    If the person you need to report is the workshop organiser, please contact the
+    <a class="btn btn-warning" href="mailto:coc@globaldiversitycfpday.com?Subject=Code%20of%20Conduct%20Issue&body=Location%0A%0AIssue">Global Code of Conduct Team</a>
+  </p>
+</section>
+<section class="CodeOfConduct__Section">
 <h2>Global Code of Conduct Team</h2>
 
 <div class="jumbotron volunteer">
@@ -180,10 +178,10 @@
     </div>
   </div>
 </div>
-
-<br/>
-
+</section>
+<section class="CodeOfConduct__Section">
 <h2>Issue Log</h2>
+<div class="CodeOfConduct__Issue">
 <h3>March 2019</h3>
 <p>
   One of our mentors has been removed during a workshop for enabling exclusionary language.
@@ -194,7 +192,8 @@
 <p>
   As such, this incident demonstrated the mentors values were not inline with that of Global Diversity CFP Day and they will not participate in future events.
 </p>
-
+</div>
+<div class="CodeOfConduct__Issue">
 <h3>February 2019</h3>
 <p>
   We have received reports from the community that one of our workshop organisers behaved in an inappropriate manner out with Global Diversity CFP Day.
@@ -202,7 +201,8 @@
 <p>
   In order to maintain the safety of people from marginalised groups, this organiser will no longer be allowed to participate in any Global Diversity CFP Day events.
 </p>
-
+</div>
+<div class="CodeOfConduct__Issue">
 <h3>January 2019</h3>
 <p>
   Thank you to numerous members of the community for reaching out to inform us that an individual publicly considering running a Global Diversity CFP Day workshop, would not provide the safe, inclusive environment our attendees deserve.
@@ -210,7 +210,8 @@
 <p>
   We have been in touch with the individual and they will not be participating in any Global Diversity CFP Day events.
 </p>
-
+</div>
+<div class="CodeOfConduct__Issue">
 <h3>September 2018</h3>
 <p>
   Having received a number of reports about the inappropriate behaviour of two workshop organisers, outside of Global Diversity CFP Day, they have been banned from participating in any future Global Diversity CFP Day events.
@@ -224,5 +225,5 @@
 <p>
   Our aim is to cultivate a positive, inclusive environment and it is our responsibility is to maintain this environment for everyone.
 </p>
-
-<br/>
+</div>
+</section>


### PR DESCRIPTION
### Summary
This commit adds padding to the Code of Conduct page and moves away from using <br /> tags for spacing.

### Notes
I've added an scss file for this page, and used [BEM notation](http://getbem.com/) to avoid css class name conflicts across pages.

-----
### old
<img width="1169" alt="image" src="https://user-images.githubusercontent.com/6391616/64431872-31847b00-d0b3-11e9-81dc-dcbf92d5a89f.png">

### new
<img width="1169" alt="image" src="https://user-images.githubusercontent.com/6391616/64431980-74dee980-d0b3-11e9-93a4-3ea3f382ff49.png">
