### PR TITLE
Introduce ability to have many facilitators, rather than one facilitator per workshop

### DIFF
--- a/app/controllers/coc_trainings_controller.rb
+++ b/app/controllers/coc_trainings_controller.rb
@@ -26,6 +26,6 @@ class CocTrainingsController < ApplicationController
   private
 
   def user_params
-    params.permit(:email, :facilitator, :mentor)
+    params.permit(:email, :organiser, :facilitator, :mentor)
   end
 end

--- a/app/controllers/invite_team_members_controller.rb
+++ b/app/controllers/invite_team_members_controller.rb
@@ -9,6 +9,6 @@ class InviteTeamMembersController < ApplicationController
   private
 
   def user_params
-    params.permit(:email, :facilitator, :mentor)
+    params.permit(:email, :organiser, :facilitator, :mentor)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,6 +13,6 @@ class UsersController < ApplicationController
 
   def user_belongs_to_workshop?
     @user = User.find(params[:id])
-    ([current_workshop.facilitator] + current_workshop.mentors).include? @user
+    ([current_workshop.organiser] + current_workshop.facilitators + current_workshop.mentors).include? @user
   end
 end

--- a/app/controllers/workshops_controller.rb
+++ b/app/controllers/workshops_controller.rb
@@ -97,7 +97,6 @@ class WorkshopsController < ApplicationController
     :alternative_date,
     :ticketing_url,
     :organiser_id,
-    :facilitator_id,
     :notes,
     :access_information_prodivded,
     :public_transport_near_venue,

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -85,6 +85,10 @@ class Workshop < ApplicationRecord
     @facilitator ||= User.where(workshop_id: id, facilitator: true).first
   end
 
+  def facilitators
+    [facilitator]
+  end
+
   def mentors
     @mentors ||= User.where(workshop_id: id, mentor: true)
   end

--- a/app/models/workshop.rb
+++ b/app/models/workshop.rb
@@ -15,7 +15,7 @@ class Workshop < ApplicationRecord
     "time_zone",
     "ticketing_url",
     "organiser",
-    "facilitator",
+    "facilitators",
     "mentors"
   ]
 
@@ -40,7 +40,11 @@ class Workshop < ApplicationRecord
   def signed_up_team
     result = []
     result << organiser unless organiser.nil? || awaiting_invitation_acceptance?(organiser)
-    result << facilitator unless facilitator.nil? || awaiting_invitation_acceptance?(facilitator)
+
+    facilitators.each do |facilitator|
+      result << facilitator unless facilitator.nil? || awaiting_invitation_acceptance?(facilitator)
+    end
+
     mentors.each do |mentor|
       result << mentor unless mentor.nil? || awaiting_invitation_acceptance?(mentor)
     end
@@ -58,7 +62,10 @@ class Workshop < ApplicationRecord
 
   def migrate_team_to!(workshop_for_2020)
     organiser.update workshop: workshop_for_2020 if organiser.present?
-    facilitator.update workshop: workshop_for_2020 if facilitator.present?
+
+    facilitators.each do |facilitator|
+      facilitator.update workshop: workshop_for_2020
+    end
 
     mentors.each do |mentor|
       mentor.update workshop: workshop_for_2020
@@ -81,12 +88,8 @@ class Workshop < ApplicationRecord
     @organiser ||= User.where(workshop_id: id, organiser: true).first
   end
 
-  def facilitator
-    @facilitator ||= User.where(workshop_id: id, facilitator: true).first
-  end
-
   def facilitators
-    [facilitator]
+    @facilitators ||= User.where(workshop_id: id, facilitator: true)
   end
 
   def mentors

--- a/app/views/admin/workshops/index.html.erb
+++ b/app/views/admin/workshops/index.html.erb
@@ -16,12 +16,12 @@
             </div>
           <% end %>
 
-          <% if workshop.facilitator.present? %>
+          <% if workshop.facilitators.each do |facilitator| %>
             <% unless awaiting_invitation_acceptance? workshop.facilitator %>
               <div> - facilitated by
-                <%= user_name workshop.facilitator %>
-                <%= coc_completed workshop.facilitator %>
-                <%= "Invited" if awaiting_invitation_acceptance? workshop.facilitator %>
+                <%= user_name facilitator %>
+                <%= coc_completed facilitator %>
+                <%= "Invited" if awaiting_invitation_acceptance? facilitator %>
               </div>
             <% end %>
           <% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -30,9 +30,13 @@
 <% end %>
 
 
-<% if @workshop.facilitator.present? && @workshop.facilitator.accepted_or_not_invited? %>
-  <h2>Facilitator</h2>
-  <%= render "volunteer", volunteer: @workshop.facilitator %>
+<% if @workshop.facilitators.present? %>
+  <% @workshop.facilitators.each do |facilitator| %>
+    <% if facilitator.accepted_or_not_invited? %>
+      <h2>Facilitator</h2>
+      <%= render "volunteer", volunteer: facilitator %>
+    <% end %>
+  <% end %>
 <% end %>
 
 <% if @workshop.mentors.present? %>

--- a/app/views/workshops/index.html.erb
+++ b/app/views/workshops/index.html.erb
@@ -15,7 +15,7 @@
       <th>Time zone</th>
       <th>Ticketing url</th>
       <th>Organiser</th>
-      <th>Facilitator</th>
+      <th>Facilitators</th>
       <th>Mentors</th>
       <th>Notes</th>
       <th colspan="3"></th>
@@ -35,7 +35,11 @@
         <td><%= workshop.time_zone %></td>
         <td><%= workshop.ticketing_url %></td>
         <td><%= user_name workshop.organiser %></td>
-        <td><%= user_name workshop.facilitator %></td>
+        <td>
+          <% workshop.facilitators.each do |facilitator| %>
+            <%= user_name facilitator %>
+          <% end %>
+        </td>
         <td>
           <% workshop.mentors.each do |mentor| %>
             <p><%= user_name mentor %></p>

--- a/app/views/workshops/show.html.erb
+++ b/app/views/workshops/show.html.erb
@@ -42,7 +42,7 @@
     </p>
   </div>
 
-  <div class="grouping">
+<!--   <div class="grouping">
     <h2>Attendees</h2>
     <p>
       <strong>Number of sign ups:</strong>
@@ -55,7 +55,7 @@
     </p>
 
   </div>
-
+ -->
   <div class="grouping">
     <h2>Where</h2>
     <p>

--- a/app/views/workshops/show.html.erb
+++ b/app/views/workshops/show.html.erb
@@ -18,6 +18,31 @@
   <br/>
 
   <div class="grouping">
+    <h2>Team</h2>
+    <p>
+      <strong>Organiser:</strong>
+      <%= user_name @workshop.organiser %>
+      <strong>CoC Training: </strong> <%= @workshop.organiser.coc_training_complete? ? "✅" : "🚫" %>
+    </p>
+    <p>
+      <% @workshop.facilitators.each do |facilitator| %>
+        <%= render 'display_user', user: facilitator, user_type: "Facilitator" %>
+        <br>
+      <% end %>
+      <%= render 'invite_user', user_type: "Facilitator" %>
+    </p>
+    <p>
+      <% @workshop.mentors.each do |mentor| %>
+        <p>
+          <%= render 'display_user', user: mentor, user_type: "Mentor" %>
+        </p>
+      <% end %>
+
+      <%= render 'invite_user', user_type: "Mentor" %>
+    </p>
+  </div>
+
+  <div class="grouping">
     <h2>Attendees</h2>
     <p>
       <strong>Number of sign ups:</strong>
@@ -87,31 +112,6 @@
     <p>
       <strong>Ticketing url:</strong>
       <%= @workshop.ticketing_url %>
-    </p>
-  </div>
-
-  <div class="grouping">
-    <h2>Team</h2>
-    <p>
-      <strong>Organiser:</strong>
-      <%= user_name @workshop.organiser %>
-      <strong>CoC Training: </strong> <%= @workshop.organiser.coc_training_complete? ? "✅" : "🚫" %>
-    </p>
-    <p>
-      <% if @workshop.facilitator.present? %>
-        <%= render 'display_user', user: @workshop.facilitator, user_type: "Facilitator" %>
-      <% else %>
-        <%= render 'invite_user', user_type: "Facilitator" %>
-      <% end %>
-    </p>
-    <p>
-      <% @workshop.mentors.each do |mentor| %>
-        <p>
-          <%= render 'display_user', user: mentor, user_type: "Mentor" %>
-        </p>
-      <% end %>
-
-      <%= render 'invite_user', user_type: "Mentor" %>
     </p>
   </div>
 

--- a/spec/models/workshop_spec.rb
+++ b/spec/models/workshop_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Workshop, type: :model do
     it "handle previous facilitator being nil" do
       facilitator.destroy
       new_workshop = original_workshop.duplicate_for_2020(organiser)
-      expect(new_workshop.facilitator).to be_nil
+      expect(new_workshop.facilitators).to be_empty
     end
 
     it "previous facilitator is migrated to new workshop" do
@@ -108,10 +108,10 @@ RSpec.describe Workshop, type: :model do
       expect(facilitator.workshop).to eql(new_workshop)
 
       new_workshop.reload
-      expect(new_workshop.facilitator).to eql(facilitator)
+      expect(new_workshop.facilitators).to include(facilitator)
 
       reloaded_original_workshop = Workshop.unscoped.find(original_workshop.id)
-      expect(reloaded_original_workshop.facilitator).to be_nil
+      expect(reloaded_original_workshop.facilitators).to be_empty
     end
 
     it "handle previous workshop with no mentors" do
@@ -193,23 +193,24 @@ RSpec.describe Workshop, type: :model do
     end
   end
 
-  describe "#facilitator" do
-    let!(:workshop) { Workshop.create }
+  describe "#facilitators" do
+    let!(:workshop) { create_workshop(city: "Edinburgh", year: nil) }
     let!(:facilitator) { create_user(facilitator: true, workshop: workshop) }
 
     it "provides the facilitator" do
-      expect(workshop.facilitator).to eql(facilitator)
+      expect(workshop.facilitators).to include(facilitator)
     end
 
     it "ignores unlreated facilitators" do
       other_facilitator = create_user(facilitator: true, email: 'other_facilitator@example.com')
-      expect(workshop.facilitator).to eql(facilitator)
+      expect(workshop.facilitators).not_to include(other_facilitator)
     end
 
     it "ignores different kinds of team members" do
       organiser = create_user(organiser: true, email: 'organiser@example.com')
       mentor = create_user(mentor: true, email: 'mentor@example.com')
-      expect(workshop.facilitator).to eql(facilitator)
+      expect(workshop.facilitators).to include(facilitator)
+      expect(workshop.facilitators.length).to eql(1)
     end
   end
 


### PR DESCRIPTION
Addresses Issue https://github.com/JiggyPete/global-diversity-cfp-day-site/issues/48

First pass was to introduce a :facilitators method on the `Workshop` class.
The dummy implementation of this was
`return [facilitator]`

Having this in place allows us to break changes down into smaller parts.
In this case we can move all client code from speaking to `workshop.facilitator` over to `workshop.facilitators`, before further updating the model itself.

Once that is in place and working, the model is updated.